### PR TITLE
removeEventListener没有handler参数情况的判断

### DIFF
--- a/src/baidu/lang/Event.js
+++ b/src/baidu/lang/Event.js
@@ -73,10 +73,12 @@ baidu.lang.Class.prototype.addEventListener = function (type, handler, key) {
  * @remark 	如果第二个参数handler没有被绑定到对应的自定义事件中，什么也不做。
  */
 baidu.lang.Class.prototype.removeEventListener = function (type, handler) {
-    if (baidu.lang.isFunction(handler)) {
-        handler = handler.hashCode;
-    } else if (!baidu.lang.isString(handler)) {
-        return;
+    if (typeof handler != "undefined") {
+        if (baidu.lang.isFunction(handler)) {
+            handler = handler.hashCode;
+        } else if (!baidu.lang.isString(handler)) {
+            return;
+        }
     }
 
     !this.__listeners && (this.__listeners = {});
@@ -87,7 +89,13 @@ baidu.lang.Class.prototype.removeEventListener = function (type, handler) {
     if (!t[type]) {
         return;
     }
-    t[type][handler] && delete t[type][handler];
+    if (typeof handler != "undefined") {
+        t[type][handler] && delete t[type][handler];
+    } else {
+        for(var guid in t[type]){
+            delete t[type][guid];
+        }
+    }
 };
 
 /**

--- a/test/baidu/lang/Event.js
+++ b/test/baidu/lang/Event.js
@@ -70,6 +70,28 @@ module("baidu.lang.Event");
 			ok(true,"listner is removed");
 
 		});
+
+    test("removeEventListener - no handler", function () {  // 2011-2-26, 无handler参数时移除所有事件
+		function myClass() {
+			this.name = "myclass";
+		}
+
+		_inherits(myClass, baidu.lang.Class);// 通过继承baidu.lang.Class来获取它的dispatchEvent方法
+		   expect(3);
+			var obj = new myClass();
+			function listner1(){ok(true, "listner1 is added");}
+			function listner2(){ok(true, "listner2 is added");}
+
+			var myEventWithoutOn = new (baidu.lang.Event)("onMyEvent", obj);
+			obj.addEventListener("onMyEvent",listner1);
+			obj.addEventListener("onMyEvent",listner2);
+			obj.dispatchEvent(myEventWithoutOn);
+			obj.removeEventListener("onMyEvent");
+			obj.dispatchEvent(myEventWithoutOn);
+			ok(true,"listner is removed");
+           
+    });
+
 })();
 
 /*


### PR DESCRIPTION
按照 http://tangram.baidu.com/tangram/tutorial_1.html 的教程，发现执行removeEventListener后事件并未取消。看到源码里是因为未对第二个参数是否为undeinfed做判断。

之前提交到master了，重新提交一次。
尝试在test中也加入了没有handler参数的情况，仿照其他test的写法。
