### PR TITLE
参数保护

### DIFF
--- a/src/baidu/sio/callByServer.js
+++ b/src/baidu/sio/callByServer.js
@@ -34,7 +34,15 @@ baidu.sio.callByServer = function(url, callback, opt_options) {
         charset = options['charset'],
         queryField = options['queryField'] || 'callback',
         timeOut = options['timeOut'] || 0,
-        timer;
+        timer,reg;
+
+    if(!callback){
+        if(reg = new RegExp('(\\?|&)callback=([^&]*)', 'gi').exec(url)){
+            callback = reg[2];
+        }else{
+            callback = new Function();
+        }
+    }
 
     if (baidu.lang.isFunction(callback)) {
         callbackName = prefix + Math.floor(Math.random() * 2147483648).toString(36);


### PR DESCRIPTION
当第二个参数为undefined且第一个参数url中存在callback参数，则callback会被至为undefined
