### PR TITLE
修改element传入 node为select情况的bug

### DIFF
--- a/src/baidu/element.js
+++ b/src/baidu/element.js
@@ -50,7 +50,8 @@ baidu.element.Element = function(node){
      * @private
      * @type {Array.<Node>}
      */
-    this._dom = baidu.lang.toArray(node);
+    this._dom = (node.tagName || '').toLowerCase() == 'select' ? 
+    	[node] : baidu.lang.toArray(node);
 };
 
 /**


### PR DESCRIPTION
[Bugfix] #53 element传入node为select的时候，调用toArray会把select当成options的nodelist
element：添加select情况的判断，当node为select的时候，不调用toArray
