### PR TITLE
更改用例，屏蔽浏览器差异

### DIFF
--- a/test/baidu/dom/ready.js
+++ b/test/baidu/dom/ready.js
@@ -40,14 +40,16 @@ test('ready after onload', function() {
 		var script = document.createElement('script');
 		script.src = '../../tools/br/import.php?f=baidu.dom.ready';
 		var fun = function(){
-			ok(true, "onload");
-			baidu.dom.ready(function() {
-				ok(true, "dom ready");
-				start();
-			});
+			if(ua.browser.ie && this.readyState == 'loaded'){
+				ok(true, "onload");
+				baidu.dom.ready(function() {
+						ok(true, "dom ready");
+						start();	
+				});
+			}
 		};
 		if(ua.browser.ie){
-			script.onreadystatechange = fun; //IE中不能用onload
+			script.onreadystatechange = fun; 
 		}
 		else{
 			script.onload = fun;	

--- a/test/baidu/dom/ready.js
+++ b/test/baidu/dom/ready.js
@@ -40,7 +40,7 @@ test('ready after onload', function() {
 		var script = document.createElement('script');
 		script.src = '../../tools/br/import.php?f=baidu.dom.ready';
 		var fun = function(){
-			if(ua.browser.ie && this.readyState == 'loaded'){
+			if(ua.browser.ie && this.readyState == 'loaded' || !ua.browser.ie){
 				ok(true, "onload");
 				baidu.dom.ready(function() {
 						ok(true, "dom ready");


### PR DESCRIPTION
[Testcase]屏蔽ie与其他浏览器的差异
dom.ready：ie的onstatechange会触发两次，产生4个断言，为了使ie和其他浏览器的断言数一致，加上一个条件限制
