### PR TITLE
swf.create函数BUG修复

### DIFF
--- a/src/baidu/swf/create.js
+++ b/src/baidu/swf/create.js
@@ -8,6 +8,7 @@
  * date: 2009/11/17
  */
 
+///import baidu.dom.insertHTML;
 ///import baidu.swf.createHTML;
 
 /**
@@ -54,10 +55,5 @@ baidu.swf.create = function (options, target) {
     if (target && 'string' == typeof target) {
         target = document.getElementById(target);
     }
-    
-    if (target) {
-        target.innerHTML = html;
-    } else {
-        document.write(html);
-    }
+    baidu.dom.insertHTML( target || document.body ,'beforeEnd',html );
 };


### PR DESCRIPTION
[Bugfix] 在create时候调用document.write页面内容会被清空
baidu.swf.create：使用baidu.dom.insertHTML代替原有的document.write插入操作。
