### PR TITLE
更新构建脚本

### DIFF
--- a/release/build_run.xml
+++ b/release/build_run.xml
@@ -53,7 +53,8 @@
 		<!-- junit report and mail end -->
 	</target>
 	<target name="getreport_j" depends="init,coverage,execute_j">
-		<waitfor maxwait="300" maxwaitunit="second">
+		<waitfor maxwait="1800" maxwaitunit="second">
+			<!-- 5分钟跑不出来结果，实际观察发现执行耗时20分钟，此处调整为等待半小时 -->
 			<available file="${report.file}" />
 		</waitfor>
 	</target>

--- a/release/build_run.xml
+++ b/release/build_run.xml
@@ -44,7 +44,7 @@
 		<get src="http://${serverip}/addTask?proj=${git.user}.${git.project}" dest="/tmp/${git.uesr}_${git.project}.php"/>
 	</target>
 	<target name="getreport" depends="init,coverage,execute">
-		<waitfor maxwait="300" maxwaitunit="second">
+		<waitfor maxwait="30" maxwaitunit="minute">
 			<available file="${report.file}" />
 		</waitfor>
 
@@ -53,7 +53,7 @@
 		<!-- junit report and mail end -->
 	</target>
 	<target name="getreport_j" depends="init,coverage,execute_j">
-		<waitfor maxwait="1800" maxwaitunit="second">
+		<waitfor maxwait="30" maxwaitunit="minute">
 			<!-- 5分钟跑不出来结果，实际观察发现执行耗时20分钟，此处调整为等待半小时 -->
 			<available file="${report.file}" />
 		</waitfor>


### PR DESCRIPTION
[test] 因执行超时导致构建失败
WHERE : release/build_run.xml
更新脚本中关于报告的等待时间为30分钟
