### PR TITLE
去掉代码中的eval()调用

### DIFF
--- a/src/baidu/lang/module.js
+++ b/src/baidu/lang/module.js
@@ -32,7 +32,7 @@ baidu.lang.module = function(name, module, owner) {
             if (!(new RegExp('^[a-zA-Z_\x24][a-zA-Z0-9_\x24]*\x24')).test(packages[0])) {
                 throw '';
             }
-            owner = eval(packages[0]);
+            owner = (new Function('return ' + packages[0]))();
             i = 1;
         }catch (e) {
             owner = window;


### PR DESCRIPTION
改为`(new Function ('return ' + xxx))()`的方式。在使用外围大闭包进行更进一步内部代码压缩时，避免出现由于`eval`存在压缩器无法完成名字压缩的情况。
